### PR TITLE
Optional DNS resolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "react/stream": "0.4.*",
         "react/promise": "~2.0",
         "react/dns": "0.4.*",
-        "react/socket-client": "0.4.*",
+        "react/socket-client": "^0.5",
         "evenement/evenement": "~2.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
This PR upgrade to react/socket-client 0.5 and make the use of DNS resolver optional for gearman connections. Fallback to google DNS is very unlikely without an explicit configuration of the user.

Using a resolver is always possible:
```php
$resolverFactory = new \React\Dns\Resolver\Factory();
$resolver = $resolverFactory->create('8.8.8.8', $loop);
$factory = new \Zikarsky\React\Gearman\Factory($loop, $resolver);
$factory->createClient('my-domain.tld', 4730)->then(
    function (ClientInterface $client) {
        ...
    }
)
```