### PR TITLE
System tests + complete client implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - composer install --dev
 
 script:
-  - bin/phpunit --coverage-text 
+  - bin/phpunit --coverage-text --exclude-group system
   - bin/php-cs-fixer fix --dry-run --diff -vv
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "react/dns": "0.4.*",
         "react/socket-client": "^0.5",
         "evenement/evenement": "~2.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "ramsey/uuid": "^3.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3",
-        "friendsofphp/php-cs-fixer": "^2.3"
+        "friendsofphp/php-cs-fixer": "^2.3",
+        "amphp/react-adapter": "^1.0"
     },
     "license": "MIT",
     "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -267,6 +267,7 @@ class Client extends Participant implements ClientInterface
     public function cancel(TaskInterface $task)
     {
         $task->removeAllListeners();
+        $this->setTaskDone($task);
     }
 
     /**
@@ -290,7 +291,8 @@ class Client extends Participant implements ClientInterface
         $task = $this->getTaskByHandle($handle);
 
         if ($task === null) {
-            throw new ProtocolException("Unexpected $command. Task unknown");
+            $this->emit('task-unknown', [$handle, $command->getName()]);
+            return;
         }
 
         switch ($command->getName()) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,6 +68,12 @@ class Client extends Participant implements ClientInterface
         }
 
         $this->getConnection()->stream->pause();
+        $this->on("close", function () {
+            foreach ($this->tasks as $task) {
+                $task->emit('exception', [new TaskDataEvent($task, 'Lost connection'), $this]);
+                $this->setTaskDone($task);
+            }
+        });
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -67,7 +67,7 @@ class Client extends Participant implements ClientInterface
             $this->getConnection()->on($event, [$this, 'handleWorkEvent']);
         }
 
-        $this->getConnection()->stream->pause();
+        $this->getConnection()->pause();
         $this->on("close", function () {
             foreach ($this->tasks as $task) {
                 $task->emit('exception', [new TaskDataEvent($task, 'Lost connection'), $this]);
@@ -348,16 +348,11 @@ class Client extends Participant implements ClientInterface
         }
     }
 
-    protected function getSocket()
-    {
-        return $this->getConnection()->stream->stream;
-    }
-
     protected function blockingActionStart()
     {
         parent::blockingActionStart();
         $this->pendingActions++;
-        $this->getConnection()->stream->resume();
+        $this->getConnection()->resume();
     }
 
     protected function blockingActionEnd()
@@ -371,7 +366,7 @@ class Client extends Participant implements ClientInterface
     protected function taskStart()
     {
         if (count($this->tasks) == 0) {
-            $this->getConnection()->stream->resume();
+            $this->getConnection()->resume();
         }
     }
 
@@ -388,7 +383,7 @@ class Client extends Participant implements ClientInterface
     protected function disableReadableIfNoTasks()
     {
         if (!$this->hasPendingTasks()) {
-            $this->getConnection()->stream->pause();
+            $this->getConnection()->pause();
             foreach ($this->waitingPromises as $promise) {
                 $promise->resolve();
             }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -71,4 +71,11 @@ interface ClientInterface
      * Disconnects the client from the server
      */
     public function disconnect();
+
+    /**
+     * Waits until all pending tasks + submits have finished
+     *
+     * @return Promise
+     */
+    public function wait();
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -31,9 +31,22 @@ interface ClientInterface
      * @param  string  $function
      * @param  string  $workload
      * @param  string  $priority defaults to TaskInterface::PRIORITY_NORMAL
+     * @param  string  $uniqueId
      * @return Promise
      */
-    public function submit($function, $workload, $priority = TaskInterface::PRIORITY_NORMAL);
+    public function submit($function, $workload, $priority = TaskInterface::PRIORITY_NORMAL, $uniqueId = '');
+
+    /**
+     * Submits a task to the server, promise is resolved on task creation with a TaskInterface
+     * Also the task-created event is fired
+     *
+     * @param  string  $function
+     * @param  string  $workload
+     * @param  string  $priority defaults to TaskInterface::PRIORITY_NORMAL
+     * @param  string  $uniqueId
+     * @return Promise
+     */
+    public function submitBackground($function, $workload, $priority = TaskInterface::PRIORITY_NORMAL, $uniqueId = '');
 
     /**
      * Sets an option for the client, promise is resolved when option is set with the option_name

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -68,6 +68,13 @@ interface ClientInterface
     public function getStatus($task);
 
     /**
+     * Cancel a task and its promise resolution
+     *
+     * @param  string|TaskInterface $task
+     */
+    public function cancel(TaskInterface $task);
+
+    /**
      * Disconnects the client from the server
      */
     public function disconnect();

--- a/src/Command/Binary/CommandFactory.php
+++ b/src/Command/Binary/CommandFactory.php
@@ -68,7 +68,7 @@ class CommandFactory implements CommandFactoryInterface
     public function getTypeByName($name)
     {
         if (!is_string($name) || !isset($this->typesByName[$name])) {
-            throw new InvalidArgumentException(__METHOD__  . ' requires $name to be a CommandType identifying name-string');
+            throw new InvalidArgumentException(__METHOD__  . " requires $name to be a CommandType identifying name-string");
         }
 
         return $this->typesByName[$name];

--- a/src/Command/Binary/DefaultCommandFactory.php
+++ b/src/Command/Binary/DefaultCommandFactory.php
@@ -18,11 +18,7 @@ class DefaultCommandFactory extends CommandFactory
         $this->addType(new CommandType("JOB_ASSIGN",            11,  ['job_handle', 'function_name', Command::DATA]));
         $this->addType(new CommandType("WORK_STATUS",           12,  ['job_handle', 'complete_numerator', 'complete_denominator']));
         $this->addType(new CommandType("WORK_COMPLETE",         13,  ['job_handle', Command::DATA]));
-        /*
-         * WORK_FAIL should have only 1 argument : job_handle, but a bug? in gearman server send a \0 at the end of this response.
-         * A workaround is to consider that there are 2 arguments (as other WORK_* responses), the second one should be always empty.
-         */
-        $this->addType(new CommandType("WORK_FAIL",             14,  ['job_handle', Command::DATA]));
+        $this->addType(new CommandType("WORK_FAIL",             14,  ['job_handle']));
         $this->addType(new CommandType("GET_STATUS",            15,  ['job_handle']));
         $this->addType(new CommandType("ECHO_REQ",              16,  [Command::DATA]));
         $this->addType(new CommandType("ECHO_RES",              17,  [Command::DATA]));

--- a/src/DuplicateJobException.php
+++ b/src/DuplicateJobException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Zikarsky\React\Gearman;
+
+class DuplicateJobException extends \Exception {}

--- a/src/DuplicateJobException.php
+++ b/src/DuplicateJobException.php
@@ -2,4 +2,6 @@
 
 namespace Zikarsky\React\Gearman;
 
-class DuplicateJobException extends \Exception {}
+class DuplicateJobException extends \Exception
+{
+}

--- a/src/Job.php
+++ b/src/Job.php
@@ -95,7 +95,7 @@ class Job extends EventEmitter implements JobInterface
     {
         $this->assertStatus(self::STATUS_RUNNING);
         $this->setStatus(self::STATUS_FAILED);
- 
+
         $payload = [
             'job_handle'            => $this->getHandle(),
             CommandInterface::DATA  => $exception
@@ -108,10 +108,10 @@ class Job extends EventEmitter implements JobInterface
     {
         $this->assertStatus(self::STATUS_RUNNING);
         $this->setStatus(self::STATUS_FAILED);
-        
+
         $payload = ['job_handle' => $this->getHandle()];
 
-        return call_user_func($this->send, 'WORK_ERROR', $payload);
+        return call_user_func($this->send, 'WORK_FAIL', $payload);
     }
 
     public function complete($data = null)

--- a/src/Protocol/Connection.php
+++ b/src/Protocol/Connection.php
@@ -3,6 +3,7 @@
 namespace Zikarsky\React\Gearman\Protocol;
 
 use Evenement\EventEmitter;
+use React\Promise\RejectedPromise;
 use Zikarsky\React\Gearman\Command\Binary\CommandFactoryInterface;
 use Zikarsky\React\Gearman\Command\Binary\CommandInterface;
 use Zikarsky\React\Gearman\Command\Binary\ReadBuffer;
@@ -139,7 +140,7 @@ class Connection extends EventEmitter
     public function send(CommandInterface $command)
     {
         if ($this->isClosed()) {
-            throw new BadMethodCallException("Connection is closed. Cannot send commands anymore");
+            return new RejectedPromise(new BadMethodCallException("Connection is closed. Cannot send commands anymore"));
         }
 
         $deferred = new Deferred();

--- a/src/Protocol/Connection.php
+++ b/src/Protocol/Connection.php
@@ -141,7 +141,7 @@ class Connection extends EventEmitter
         if ($this->isClosed()) {
             throw new BadMethodCallException("Connection is closed. Cannot send commands anymore");
         }
-        
+
         $deferred = new Deferred();
         $this->logger->info("> $command");
         $this->writeBuffer->push($command);

--- a/src/Protocol/Connection.php
+++ b/src/Protocol/Connection.php
@@ -40,7 +40,7 @@ class Connection extends EventEmitter
     /**
      * @var Stream
      */
-    protected $stream;
+    public $stream;
 
     /**
      * @var CommandFactoryInterface

--- a/src/Protocol/Connection.php
+++ b/src/Protocol/Connection.php
@@ -41,7 +41,7 @@ class Connection extends EventEmitter
     /**
      * @var Stream
      */
-    public $stream;
+    protected $stream;
 
     /**
      * @var CommandFactoryInterface
@@ -104,6 +104,16 @@ class Connection extends EventEmitter
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+    }
+
+    public function pause()
+    {
+        $this->stream->pause();
+    }
+
+    public function resume()
+    {
+        $this->stream->resume();
     }
 
     /**

--- a/src/Protocol/Participant.php
+++ b/src/Protocol/Participant.php
@@ -74,6 +74,13 @@ abstract class Participant extends EventEmitter
         });
     }
 
+    protected function blockingActionStart() {
+
+    }
+
+    protected function blockingActionEnd() {
+    }
+
     /**
      * Performs a blocking action (request<->response pattern)
      *
@@ -90,6 +97,7 @@ abstract class Participant extends EventEmitter
         // create the deferred action to execute $handler on $eventName after sending $command
         $deferred = new Deferred();
         $actionPromise = $deferred->promise();
+        $this->blockingActionStart();
 
         // send command
         $this->send($command, $actionPromise)->then(
@@ -103,6 +111,7 @@ abstract class Participant extends EventEmitter
                     // itself
                     $result = $handler($sentCommand, $recvCommand, $deferred);
                     if ($result !== null) {
+                        $this->blockingActionEnd();
                         $deferred->resolve($result);
                     }
                 });

--- a/src/Protocol/Participant.php
+++ b/src/Protocol/Participant.php
@@ -74,11 +74,12 @@ abstract class Participant extends EventEmitter
         });
     }
 
-    protected function blockingActionStart() {
-
+    protected function blockingActionStart()
+    {
     }
 
-    protected function blockingActionEnd() {
+    protected function blockingActionEnd()
+    {
     }
 
     /**

--- a/src/Task.php
+++ b/src/Task.php
@@ -79,5 +79,4 @@ class Task extends EventEmitter implements TaskInterface
     {
         return $this->uniqueId;
     }
-
 }

--- a/src/Task.php
+++ b/src/Task.php
@@ -26,12 +26,18 @@ class Task extends EventEmitter implements TaskInterface
      */
     protected $priority;
 
-    public function __construct($function, $workload, $handle, $priority)
+    /**
+     * @var string
+     */
+    protected $uniqueId;
+
+    public function __construct($function, $workload, $handle, $priority, $uniqueId)
     {
         $this->function = $function;
         $this->workload = $workload;
         $this->handle   = $handle;
         $this->priority = $priority;
+        $this->uniqueId = $uniqueId;
     }
 
     /**
@@ -65,4 +71,13 @@ class Task extends EventEmitter implements TaskInterface
     {
         return $this->priority;
     }
+
+    /**
+     * @return string
+     */
+    public function getUniqueId()
+    {
+        return $this->uniqueId;
+    }
+
 }

--- a/src/TaskInterface.php
+++ b/src/TaskInterface.php
@@ -51,4 +51,11 @@ interface TaskInterface extends EventEmitterInterface
      * @return string
      */
     public function getPriority();
+
+    /**
+     * Returns the task's unique id
+     *
+     * @return string
+     */
+    public function getUniqueId();
 }

--- a/src/UnknownTask.php
+++ b/src/UnknownTask.php
@@ -64,5 +64,4 @@ class UnknownTask extends EventEmitter implements TaskInterface
     {
         return null;
     }
-
 }

--- a/src/UnknownTask.php
+++ b/src/UnknownTask.php
@@ -54,4 +54,15 @@ class UnknownTask extends EventEmitter implements TaskInterface
     {
         return null;
     }
+
+    /**
+     * Returns null since the id of an unknown task is unknown
+     *
+     * @return null
+     */
+    public function getUniqueId()
+    {
+        return null;
+    }
+
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -187,7 +187,7 @@ class Worker extends Participant implements WorkerInterface
     {
         $this->acceptNewJobs = false;
         if ($this->grabsInFlight <= 0) {
-            $this->getConnection()->stream->pause();
+            $this->getConnection()->pause();
         }
     }
 
@@ -200,7 +200,7 @@ class Worker extends Participant implements WorkerInterface
             throw new \RuntimeException("Worker is shutting down");
         }
         $this->acceptNewJobs = true;
-        $this->getConnection()->stream->resume();
+        $this->getConnection()->resume();
         $this->grabJob();
     }
 
@@ -223,7 +223,7 @@ class Worker extends Participant implements WorkerInterface
     {
         $this->grabsInFlight--;
         if ($this->grabsInFlight <= 0 && !$this->acceptNewJobs) {
-            $this->getConnection()->stream->pause();
+            $this->getConnection()->pause();
         }
 
         return $this->acceptNewJobs;

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -34,6 +34,14 @@ class Worker extends Participant implements WorkerInterface
     }
 
     /**
+     * @return int
+     */
+    public function getInflightRequests()
+    {
+        return $this->inflightRequests;
+    }
+
+    /**
      * To make full use of async I/O, jobs can be accepted and processed in parallel
      * {$$maxParallelRequests} limits the number of jobs that are accepted from
      * the gearman server before an active job has to complete or fail
@@ -123,6 +131,11 @@ class Worker extends Participant implements WorkerInterface
     {
         $this->inflightRequests++;
 
+        $this->grabJobSend();
+    }
+
+    protected function grabJobSend()
+    {
         $grab = $this->getCommandFactory()->create('GRAB_JOB');
         $this->send($grab);
     }
@@ -149,7 +162,7 @@ class Worker extends Participant implements WorkerInterface
         });
 
         if (!isset($this->functions[$job->getFunction()])) {
-            throw new \LogicException("Got job for unknown function {$job->getFunction}");
+            throw new \LogicException("Got job for unknown function {$job->getFunction()}");
         }
 
         // grab next job, when this one is completed or failed

--- a/src/WorkerInterface.php
+++ b/src/WorkerInterface.php
@@ -20,7 +20,7 @@ interface WorkerInterface
      * @return Promise
      */
     public function setId($id);
-    
+
     /**
      * Pings the server, promise is resolved on pong.
      * Also the ping event is fired
@@ -39,9 +39,9 @@ interface WorkerInterface
      * An optional $timeout in seconds can be defined after which the server
      * assumes the job to be timed out.
      *
-     * @param  string   $function
+     * @param  string $function
      * @param  callable $callback
-     * @param  int      $timeout  timeout in seconds, optional, defaults to null
+     * @param  int $timeout timeout in seconds, optional, defaults to null
      * @return Promise
      */
     public function register($function, callable $callback, $timeout = null);
@@ -75,4 +75,10 @@ interface WorkerInterface
      * Disconnects the worker from the server
      */
     public function disconnect();
+
+    /**
+     * @param $maxParallelRequests
+     * @return mixed
+     */
+    public function setMaxParallelRequests($maxParallelRequests);
 }

--- a/src/WorkerInterface.php
+++ b/src/WorkerInterface.php
@@ -85,12 +85,17 @@ interface WorkerInterface
     /**
      * Stop accepting new jobs
      */
-#	public function pause();
+    public function pause();
 
     /**
      * Accept new jobs again
      */
-#	public function resume();
+    public function resume();
+
+    /**
+     * @return JobInterface[]
+     */
+    public function getRunningJobs();
 
     /**
      * Shutdown worker gracefully
@@ -98,5 +103,5 @@ interface WorkerInterface
      *
      * @return Promise
      */
-#	public function shutdown();
+    public function shutdown();
 }

--- a/src/WorkerInterface.php
+++ b/src/WorkerInterface.php
@@ -81,4 +81,22 @@ interface WorkerInterface
      * @return mixed
      */
     public function setMaxParallelRequests($maxParallelRequests);
+
+    /**
+     * Stop accepting new jobs
+     */
+#	public function pause();
+
+    /**
+     * Accept new jobs again
+     */
+#	public function resume();
+
+    /**
+     * Shutdown worker gracefully
+     * Stop accepting new jobs, Process all pending jobs, then disconnect
+     *
+     * @return Promise
+     */
+#	public function shutdown();
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -8,7 +8,6 @@ use Zikarsky\React\Gearman\Event\TaskDataEvent;
 use Zikarsky\React\Gearman\Event\TaskEvent;
 use Zikarsky\React\Gearman\ClientInterface;
 use React\Promise\FulfilledPromise;
-use Zikarsky\React\Gearman\UnknownTask;
 
 class ClientTest extends PHPUnit_Framework_TestCase
 {
@@ -87,11 +86,18 @@ class ClientTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider taskCommandProvider
-     * @expectedException \Zikarsky\React\Gearman\Command\Exception
      */
     public function testInvalidUnknownTaskCommand($command)
     {
+    	$called = false;
+    	$this->client->once('task-unknown', function($handle, $commandName) use (&$called, $command) {
+    		$this->assertEquals('unknown', $handle);
+		    $this->assertEquals($command, $commandName);
+		    $called = true;
+	    });
+
         $this->respond($command, ["job_handle" => "unknown"]);
+        $this->assertTrue($called);
     }
 
     public function testWorkStatusEvent()

--- a/tests/Command/Binary/DefaultCommandFactoryTest.php
+++ b/tests/Command/Binary/DefaultCommandFactoryTest.php
@@ -25,9 +25,9 @@ class DefaultCommandFactoryTest extends PHPUnit_Framework_TestCase
     public function testWorkFailCommand()
     {
         $jobHandle = 'H:toto:42';
-        $length = strlen($jobHandle) + 1;
+        $length = strlen($jobHandle);
         $type = 14;
-        $rawCommand = "\x00RES".pack('N', $type).pack('N', $length).$jobHandle."\x00";
+        $rawCommand = "\x00RES".pack('N', $type).pack('N', $length).$jobHandle;
 
         $factory = new \Zikarsky\React\Gearman\Command\Binary\DefaultCommandFactory();
 

--- a/tests/Protocol/ConnectionTest.php
+++ b/tests/Protocol/ConnectionTest.php
@@ -60,11 +60,15 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
 
     /**
      * @depends testStreamClose
-     * @expectedException BadMethodCallException
      */
     public function testSendFailOnClosedConnection(Connection $connection)
     {
-        $connection->send($this->packet);
+        $thrown = null;
+        $connection->send($this->packet)->otherwise(function ($e) use (&$thrown) {
+            $thrown = $e;
+        });
+
+        $this->assertInstanceOf(BadMethodCallException::class, $thrown);
     }
 
     public function testHandledPacketEvent()

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -14,7 +14,6 @@ use Zikarsky\React\Gearman\WorkerInterface;
  */
 class SystemTest extends PHPUnit_Framework_TestCase
 {
-
     protected function asyncTest(callable $coroutine)
     {
         \Amp\Loop::set((new \Amp\Loop\DriverFactory)->create());
@@ -252,7 +251,6 @@ class SystemTest extends PHPUnit_Framework_TestCase
             try {
                 yield $client->submit($queueName, 'TestData3a', TaskInterface::PRIORITY_LOW, '3');
             } catch (Exception $e) {
-
             }
             $task3 = yield $client->submit($queueName, 'TestData4', TaskInterface::PRIORITY_HIGH, '4');
 
@@ -480,5 +478,4 @@ class SystemTest extends PHPUnit_Framework_TestCase
             $worker->disconnect();
         });
     }
-
 }

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -1,0 +1,443 @@
+<?php
+
+use Zikarsky\React\Gearman\ClientInterface;
+use Zikarsky\React\Gearman\DuplicateJobException;
+use Zikarsky\React\Gearman\Event\TaskDataEvent;
+use Zikarsky\React\Gearman\Event\TaskEvent;
+use Zikarsky\React\Gearman\JobInterface;
+use Zikarsky\React\Gearman\TaskInterface;
+use Zikarsky\React\Gearman\UnknownTask;
+use Zikarsky\React\Gearman\WorkerInterface;
+
+class SystemTest extends PHPUnit_Framework_TestCase
+{
+
+    protected function asyncTest(callable $coroutine)
+    {
+        \Amp\Loop::set((new \Amp\Loop\DriverFactory)->create());
+        gc_collect_cycles(); // extensions using an event loop may otherwise leak the file descriptors to the loop
+        return \Amp\Promise\wait(\Amp\call($coroutine));
+    }
+
+    protected function getFactory()
+    {
+        $loop = \Amp\ReactAdapter\ReactAdapter::get();
+        return new \Zikarsky\React\Gearman\Factory($loop);
+    }
+
+    protected function getWorkerAndClient()
+    {
+        $factory = $this->getFactory();
+
+        /**
+         * @var ClientInterface $client
+         * @var WorkerInterface $worker
+         */
+        $client = yield $factory->createClient('127.0.0.1', 4730);
+        $worker = yield $factory->createWorker('127.0.0.1', 4730);
+        return [$client, $worker];
+    }
+
+    protected function getTaskPromise(TaskInterface $task, callable $onTask)
+    {
+        $deferred = new \Amp\Deferred();
+
+        $watcher = \Amp\Loop::delay(200, function () use ($deferred, $task) {
+            $deferred->fail(new Exception("Job timed out: {$task->getWorkload()}"));
+        });
+
+        $task->on('complete', function (TaskDataEvent $event, ClientInterface $client) use ($deferred, $onTask, $watcher) {
+            \Amp\Loop::cancel($watcher);
+            try {
+                $onTask($event, $client);
+                $deferred->resolve();
+            } catch (Throwable $e) {
+                $deferred->fail($e);
+            }
+        });
+
+        $task->on('exception', function (TaskDataEvent $event, ClientInterface $client) use ($deferred, $onTask, $watcher) {
+            \Amp\Loop::cancel($watcher);
+            $deferred->fail(new Exception($event->getData()));
+        });
+
+        $task->on('failure', function (TaskEvent $event, ClientInterface $client) use ($deferred, $onTask, $watcher) {
+            \Amp\Loop::cancel($watcher);
+            $deferred->fail(new Exception("N/A"));
+        });
+
+        return $deferred->promise();
+    }
+
+    public function testSubmitAndWork()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            $workerCalled = false;
+            $responseReceived = false;
+            yield $worker->register('test', function (JobInterface $job) use (&$workerCalled) {
+                $job->complete($job->getWorkload());
+                $workerCalled = true;
+            });
+
+            /**
+             * @var TaskInterface $task
+             */
+            $task = yield $client->submit('test', 'TestData');
+
+            yield $this->getTaskPromise($task, function (TaskDataEvent $event, ClientInterface $client) use (&$responseReceived) {
+                $responseReceived = true;
+                $this->assertEquals('TestData', $event->getData());
+                $client->disconnect();
+            });
+
+            $this->assertTrue($workerCalled);
+            $this->assertTrue($responseReceived);
+        });
+    }
+
+    public function testSubmitBackgroundAndWork()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            $workerCalled = false;
+
+            $task = yield $client->submitBackground('test', 'TestData');
+            $this->assertInstanceOf(TaskInterface::class, $task);
+
+            $deferred = new \Amp\Deferred();
+
+            yield $worker->register('test', function (JobInterface $job) use (&$workerCalled, $deferred) {
+                $job->complete($job->getWorkload());
+                $workerCalled = true;
+                $this->assertEquals('TestData', $job->getWorkload());
+                $deferred->resolve();
+            });
+
+            \Amp\Loop::delay(100, function () use ($deferred) {
+                $deferred->fail(new Exception("Job timed out"));
+            });
+
+            yield $deferred->promise();
+            $this->assertTrue($workerCalled);
+        });
+    }
+
+    public function testSubmitWithUniqueIds()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            /**
+             * @var TaskInterface $task1
+             * @var TaskInterface $task2
+             * @var TaskInterface $task3
+             */
+            $task1 = yield $client->submit('test', 'TestData1', TaskInterface::PRIORITY_NORMAL, '1');
+            try {
+                yield $client->submit('test', 'TestData1a', TaskInterface::PRIORITY_NORMAL, '1');
+                $this->fail("DuplicateJobException not thrown");
+            }
+            catch (DuplicateJobException $e) {
+                // Expected
+            }
+            $task3 = yield $client->submit('test', 'TestData2', TaskInterface::PRIORITY_NORMAL, '2');
+
+            $taskPromise1 = $this->getTaskPromise($task1, function (TaskDataEvent $event, ClientInterface $client) use (&$responseReceived) {
+                $this->assertEquals('TestData1', $event->getData());
+            });
+            $taskPromise3 = $this->getTaskPromise($task3, function (TaskDataEvent $event, ClientInterface $client) use (&$responseReceived) {
+                $this->assertEquals('TestData2', $event->getData());
+            });
+
+            $deferred = new \Amp\Deferred();
+
+            $jobCalls = [];
+            yield $worker->register('test', function (JobInterface $job) use (&$jobCalls, $deferred) {
+                $job->complete($job->getWorkload());
+                $jobCalls[] = $job->getWorkload();
+                if (count($jobCalls) == 2) {
+                    $deferred->resolve();
+                }
+            });
+
+            yield $taskPromise1;
+            yield $taskPromise3;
+
+            $this->assertEquals([
+                'TestData1',
+                'TestData2',
+            ], $jobCalls);
+        });
+    }
+
+    public function testSubmitBackgroundWithUniqueIds()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            yield $client->submitBackground('test', 'TestData1', TaskInterface::PRIORITY_NORMAL, '1b');
+            yield $client->submitBackground('test', 'TestData1a', TaskInterface::PRIORITY_NORMAL, '1b');
+            yield $client->submitBackground('test', 'TestData2', TaskInterface::PRIORITY_NORMAL, '2b');
+
+            $deferred = new \Amp\Deferred();
+
+            $jobCalls = [];
+            yield $worker->register('test', function (JobInterface $job) use (&$jobCalls, $deferred) {
+                $job->complete($job->getWorkload());
+                $jobCalls[] = $job->getWorkload();
+                if (count($jobCalls) == 2) {
+                    $deferred->resolve();
+                }
+            });
+
+            \Amp\Loop::delay(100, function () use ($deferred) {
+                $deferred->fail(new Exception("Job timed out"));
+            });
+
+            yield $deferred->promise();
+            $this->assertEquals([
+                'TestData1',
+                'TestData2',
+            ], $jobCalls);
+        });
+    }
+
+    public function testSubmitWithPriorities()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            yield $client->submit('test', 'TestData3', TaskInterface::PRIORITY_LOW, '3');
+            try {
+                yield $client->submit('test', 'TestData3a', TaskInterface::PRIORITY_LOW, '3');
+            }
+            catch (Exception $e) {
+
+            }
+            yield $client->submit('test', 'TestData4', TaskInterface::PRIORITY_HIGH, '4');
+
+            $deferred = new \Amp\Deferred();
+
+            $jobCalls = [];
+            yield $worker->register('test', function (JobInterface $job) use (&$jobCalls, $deferred) {
+                $job->complete($job->getWorkload());
+                $jobCalls[] = $job->getWorkload();
+                if (count($jobCalls) == 2) {
+                    $deferred->resolve();
+                }
+            });
+
+            \Amp\Loop::delay(100, function () use ($deferred) {
+                $deferred->fail(new Exception("Job timed out"));
+            });
+
+            yield $deferred->promise();
+            $this->assertEquals([
+                'TestData4',
+                'TestData3',
+            ], $jobCalls);
+        });
+    }
+
+    public function testSubmitBackgroundWithPriorities()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            yield $client->submitBackground('test', 'TestData3', TaskInterface::PRIORITY_LOW, '3b');
+            yield $client->submitBackground('test', 'TestData3a', TaskInterface::PRIORITY_LOW, '3b');
+            yield $client->submitBackground('test', 'TestData4', TaskInterface::PRIORITY_HIGH, '4b');
+
+            $deferred = new \Amp\Deferred();
+
+            $jobCalls = [];
+            yield $worker->register('test', function (JobInterface $job) use (&$jobCalls, $deferred) {
+                $job->complete($job->getWorkload());
+                $jobCalls[] = $job->getWorkload();
+                if (count($jobCalls) == 2) {
+                    $deferred->resolve();
+                }
+            });
+
+            \Amp\Loop::delay(100, function () use ($deferred) {
+                $deferred->fail(new Exception("Job timed out"));
+            });
+
+            yield $deferred->promise();
+            $this->assertEquals([
+                'TestData4',
+                'TestData3',
+            ], $jobCalls);
+        });
+    }
+
+    public function testProgress()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            /**
+             * @var TaskInterface $task1
+             */
+            $task = yield $client->submit('test', 'TestData1', TaskInterface::PRIORITY_NORMAL, '1p');
+
+            $dataReceived = [];
+            $task->on('data', function(TaskDataEvent $event, ClientInterface $client) use (&$dataReceived) {
+                $dataReceived[] = $event->getData();
+            });
+
+            $taskPromise1 = $this->getTaskPromise($task, function (TaskDataEvent $event, ClientInterface $client) use (&$responseReceived) {
+                $this->assertEquals('TestData1', $event->getData());
+            });
+
+            $deferred = new \Amp\Deferred();
+
+            $jobCalls = [];
+            yield $worker->register('test', function (JobInterface $job) use (&$jobCalls, $deferred) {
+                $job->sendData("Some data");
+                $job->complete($job->getWorkload());
+                $jobCalls[] = $job->getWorkload();
+                $deferred->resolve();
+            });
+
+            yield $taskPromise1;
+
+            $this->assertEquals([
+                'TestData1'
+            ], $jobCalls);
+            $this->assertEquals([
+                'Some data'
+            ], $dataReceived);
+        });
+    }
+
+    public function testException()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            yield $client->setOption('exceptions');
+            /**
+             * @var TaskInterface $task1
+             */
+            $task = yield $client->submit('test', 'TestData1', TaskInterface::PRIORITY_NORMAL);
+
+            $taskPromise1 = $this->getTaskPromise($task, function (TaskDataEvent $event, ClientInterface $client) use (&$responseReceived) {
+                $this->assertEquals('TestData1', $event->getData());
+            });
+
+            yield $worker->register('test', function (JobInterface $job) use (&$jobCalls) {
+                $job->fail("Reason");
+            });
+
+            try {
+                yield $taskPromise1;
+                $this->fail("Job did not return with error");
+            }
+            catch (Exception $e) {
+                $this->assertEquals("Reason", $e->getMessage());
+            }
+        });
+    }
+
+    public function testError()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            /**
+             * @var TaskInterface $task1
+             */
+            $task = yield $client->submit('test', 'TestData1', TaskInterface::PRIORITY_NORMAL);
+
+            $taskPromise1 = $this->getTaskPromise($task, function (TaskDataEvent $event, ClientInterface $client) use (&$responseReceived) {
+                $this->assertEquals('TestData1', $event->getData());
+            });
+
+            yield $worker->register('test', function (JobInterface $job) use (&$jobCalls) {
+                $job->fail();
+            });
+
+            try {
+                yield $taskPromise1;
+                $this->fail("Job did not return with error");
+            }
+            catch (Exception $e) {
+                $this->assertEquals("N/A", $e->getMessage());
+            }
+        });
+    }
+
+    public function testWarning()
+    {
+        $this->asyncTest(function () {
+            /**
+             * @var ClientInterface $client
+             * @var WorkerInterface $worker
+             */
+            list($client, $worker) = yield from $this->getWorkerAndClient();
+
+            /**
+             * @var TaskInterface $task1
+             */
+            $task = yield $client->submit('test', 'TestData1', TaskInterface::PRIORITY_NORMAL);
+
+            $taskPromise1 = $this->getTaskPromise($task, function (TaskDataEvent $event, ClientInterface $client) use (&$responseReceived) {
+                $this->assertEquals('TestData1', $event->getData());
+            });
+
+            $warningReceived = null;
+            $task->on('warning', function(TaskDataEvent $event, ClientInterface $client) use (&$warningReceived) {
+                $warningReceived = $event->getData();
+            });
+
+            yield $worker->register('test', function (JobInterface $job) use (&$jobCalls) {
+                $job->sendWarning('A warning');
+                $job->complete('TestData1');
+            });
+
+            yield $taskPromise1;
+            $this->assertEquals("A warning", $warningReceived);
+        });
+    }
+
+}

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -6,9 +6,12 @@ use Zikarsky\React\Gearman\Event\TaskDataEvent;
 use Zikarsky\React\Gearman\Event\TaskEvent;
 use Zikarsky\React\Gearman\JobInterface;
 use Zikarsky\React\Gearman\TaskInterface;
-use Zikarsky\React\Gearman\UnknownTask;
 use Zikarsky\React\Gearman\WorkerInterface;
 
+/**
+ * Class SystemTest
+ * @group system
+ */
 class SystemTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/TaskTest.php
+++ b/tests/TaskTest.php
@@ -6,7 +6,7 @@ class TaskTest extends PHPUnit_Framework_TestCase
 {
     public function testTaskGetters()
     {
-        $task = new \Zikarsky\React\Gearman\Task("function", "workload", "handle", TaskInterface::PRIORITY_NORMAL);
+        $task = new \Zikarsky\React\Gearman\Task("function", "workload", "handle", TaskInterface::PRIORITY_NORMAL, "");
 
         $this->assertEquals("function", $task->getFunction());
         $this->assertEquals("workload", $task->getWorkload());

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -1,0 +1,230 @@
+<?php
+
+use Zikarsky\React\Gearman;
+use Zikarsky\React\Gearman\Command\Binary\Command;
+use Zikarsky\React\Gearman\Command\Binary\CommandFactory;
+use Zikarsky\React\Gearman\Command\Binary\CommandInterface;
+use Zikarsky\React\Gearman\Command\Binary\CommandType;
+use Zikarsky\React\Gearman\Protocol\Connection;
+
+class WorkerTest extends PHPUnit_Framework_TestCase
+{
+    protected function getConnection()
+    {
+        $fac = new CommandFactory();
+        $fac->addType(new CommandType("CAN_DO", 1, ['function_name']));
+        $fac->addType(new CommandType("WORK_COMPLETE", 13, ['job_handle', Command::DATA]));
+        $fac->addType(new CommandType("GRAB_JOB", 9, []));
+        $fac->addType(new CommandType("PRE_SLEEP", 4, []));
+
+        $stream = $this->getMockBuilder(\React\Stream\Stream::class)
+            ->setMethods(['write', 'close', 'getBuffer'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $buffer = $this->createMock(\React\Stream\Buffer::class);
+        $stream->expects($this->any())->method('getBuffer')->willReturn($buffer);
+        return new Connection($stream, $fac);
+    }
+
+    protected function getWorkerMock($mockedMethods = [])
+    {
+        $connection = $this->getConnection();
+        return [
+            $this->getMockBuilder(Gearman\Worker::class)
+                ->setMethods($mockedMethods)
+                ->setConstructorArgs([$connection])
+                ->getMock(),
+            $connection
+        ];
+    }
+
+    public function testEventReceiverNOOP()
+    {
+        list($worker, $connection) = $this->getWorkerMock(['grabJob']);
+        $worker->expects($this->once())->method('grabJob');
+        /**
+         * @var $connection Gearman\Protocol\Connection
+         */
+        $connection->emit('NOOP');
+    }
+
+    public function testEventReceiverNO_JOB()
+    {
+        list($worker, $connection) = $this->getWorkerMock(['handleNoJob']);
+        $worker->expects($this->once())->method('handleNoJob');
+        /**
+         * @var $connection Gearman\Protocol\Connection
+         */
+        $connection->emit('NO_JOB');
+    }
+
+    public function testEventReceiverJOB_ASSIGN()
+    {
+        list($worker, $connection) = $this->getWorkerMock(['handleJob']);
+        $worker->expects($this->once())->method('handleJob');
+        /**
+         * @var $connection Gearman\Protocol\Connection
+         */
+        $type = new CommandType("TEST", 1, ["arg1", "arg2"]);
+        $data = ["arg1" => 1];
+        $magic = CommandInterface::MAGIC_REQUEST;
+        $command = new Command($type, $data, $magic);
+
+        $connection->emit('JOB_ASSIGN', [$command]);
+    }
+
+    public function testExecute()
+    {
+        list($worker, $connection) = $this->getWorkerMock(['send']);
+
+        /**
+         * @var PHPUnit_Framework_MockObject_MockObject $worker
+         */
+        /*
+         * Called:
+         * - CAN_DO
+         * - GRAB_JOB 2x
+         * - WORK_COMPLETE
+         */
+        $worker->expects($this->exactly(4))->method('send')->will($this->returnValue(\React\Promise\resolve()));
+
+        /**
+         * @var Gearman\Worker $worker
+         */
+        $callbackWasCalled = false;
+        /**
+         * @var Gearman\JobInterface $job
+         */
+        $job = null;
+        $worker->register('foo', function ($_job) use (&$callbackWasCalled, &$job) {
+            $callbackWasCalled = true;
+            $job = $_job;
+        });
+        $type = new CommandType("JOB_ASSIGN", 11, ['job_handle', 'function_name', Command::DATA]);
+        $data = [
+            'job_handle' => 1,
+            'function_name' => 'foo'
+        ];
+        $command = new Command($type, $data, CommandInterface::MAGIC_REQUEST);
+        /**
+         * @var $connection Gearman\Protocol\Connection
+         */
+        $connection->emit('JOB_ASSIGN', [$command]);
+
+        $this->assertTrue($callbackWasCalled);
+        $this->assertEquals(1, $worker->getInflightRequests());
+
+        $job->complete("");
+        // Complete decreases inflight requests but grabJob is triggered and this increases them again
+        $this->assertEquals(1, $worker->getInflightRequests());
+    }
+
+    public function testMaxInflight()
+    {
+        list($worker, $connection) = $this->getWorkerMock(['send', 'grabJobSend']);
+
+        /**
+         * @var PHPUnit_Framework_MockObject_MockObject $worker
+         */
+        $worker->expects($this->any())->method('send')->will($this->returnValue(\React\Promise\resolve()));
+        $worker->expects($this->exactly(3))->method('grabJobSend');
+
+        /**
+         * @var Gearman\Worker $worker
+         */
+        $worker->setMaxParallelRequests(3);
+        $callbackWasCalled = 0;
+        /**
+         * @var Gearman\JobInterface $job
+         */
+        $jobs = [];
+        $worker->register('foo', function ($job) use (&$callbackWasCalled, &$jobs) {
+            $callbackWasCalled++;
+            $jobs[] = $job;
+        });
+        $type = new CommandType("JOB_ASSIGN", 11, ['job_handle', 'function_name', Command::DATA]);
+        $data = [
+            'job_handle' => 1,
+            'function_name' => 'foo'
+        ];
+        $command = new Command($type, $data, CommandInterface::MAGIC_REQUEST);
+        /**
+         * @var $connection Gearman\Protocol\Connection
+         */
+        $connection->emit('JOB_ASSIGN', [$command]);
+        $connection->emit('JOB_ASSIGN', [$command]);
+        $connection->emit('JOB_ASSIGN', [$command]);
+
+        // Last job does not trigger GRAB_JOB as already 3 jobs are ongoing. So in-flight requests are not increased any more
+        // Actually this should not happen in a real env as JOB_ASSIGN is only called as a response for GRAB_JOB
+        $connection->emit('JOB_ASSIGN', [$command]);
+
+        $this->assertEquals(4, $callbackWasCalled);
+        $this->assertEquals(3, $worker->getInflightRequests());
+
+        // Inflight requests are decreased as a result for NO_JOB response on a GRAB_JOB request
+        $connection->emit('NO_JOB');
+        $connection->emit('NO_JOB');
+        $connection->emit('NO_JOB');
+
+        $this->assertEquals(0, $worker->getInflightRequests());
+    }
+
+    public function testMaxInflightLimitReached()
+    {
+        list($worker, $connection) = $this->getWorkerMock(['send', 'grabJobSend']);
+
+        /**
+         * @var PHPUnit_Framework_MockObject_MockObject $worker
+         */
+        $worker->expects($this->any())->method('send')->will($this->returnValue(\React\Promise\resolve()));
+        $worker->expects($this->exactly(6))->method('grabJobSend');
+
+        /**
+         * @var Gearman\Worker $worker
+         */
+        $worker->setMaxParallelRequests(3);
+        $callbackWasCalled = 0;
+        /**
+         * @var Gearman\JobInterface $job
+         */
+        $jobs = [];
+        $worker->register('foo', function ($job) use (&$callbackWasCalled, &$jobs) {
+            $callbackWasCalled++;
+            $jobs[] = $job;
+        });
+        $type = new CommandType("JOB_ASSIGN", 11, ['job_handle', 'function_name', Command::DATA]);
+        $data = [
+            'job_handle' => 1,
+            'function_name' => 'foo'
+        ];
+        $command = new Command($type, $data, CommandInterface::MAGIC_REQUEST);
+        /**
+         * @var $connection Gearman\Protocol\Connection
+         */
+        $connection->emit('JOB_ASSIGN', [$command]);
+        $connection->emit('JOB_ASSIGN', [$command]);
+        $connection->emit('JOB_ASSIGN', [$command]);
+
+        // Last job does not trigger GRAB_JOB as already 3 jobs are ongoing. So in-flight requests are not increased any more
+        // Actually this should not happen in a real env as JOB_ASSIGN is only called as a response for GRAB_JOB
+        $connection->emit('JOB_ASSIGN', [$command]);
+
+        $job = array_pop($jobs);
+        $job->complete();
+        $job = array_pop($jobs);
+        $job->complete();
+        $job = array_pop($jobs);
+        $job->complete();
+
+        $this->assertEquals(4, $callbackWasCalled);
+        $this->assertEquals(3, $worker->getInflightRequests());
+
+        // Inflight requests are decreased as a result for NO_JOB response on a GRAB_JOB request
+        $connection->emit('NO_JOB');
+        $connection->emit('NO_JOB');
+        $connection->emit('NO_JOB');
+
+        $this->assertEquals(0, $worker->getInflightRequests());
+    }
+}


### PR DESCRIPTION
Hi there,

I want to use the async client in our project. But unfortunately it is missing background jobs + unique ids.
I took the occasion and completed the implementation and wrote system tests for it, which revealed some edge cases and failures.

To make the tests easier to write and to understand, I used AMPHP. Unfortunately this is only works with PHP 7.
My 2 cents: I'd like to keep it. Code is so much more beautiful and better to understand than with the react promise hell. I'd even go so far to drop support for 5.6 as it isn't even actively supported any more.

WDYT?

To run the system tests on travis, it still needs some tweaks.